### PR TITLE
Basics install check only on modification of script file

### DIFF
--- a/.github/workflows/test-basics-install.yml
+++ b/.github/workflows/test-basics-install.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow that is manually triggered
 
-name: Manual workflow
+name: Test Environment Setup
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
@@ -15,6 +15,8 @@ jobs:
   basics_install:
     # Run on a BigSur machine
     runs-on: macos-latest
+    # run this job only if the basics.sh file has been changed
+    if: contains(steps.changed-files.outputs.modified_files, 'basics.sh')
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Clone PR branch if this is triggered on a PR

--- a/.github/workflows/test-basics-install.yml
+++ b/.github/workflows/test-basics-install.yml
@@ -15,8 +15,6 @@ jobs:
   basics_install:
     # Run on a BigSur machine
     runs-on: macos-latest
-    # run this job only if the basics.sh file has been changed
-    if: contains(steps.changed-files.outputs.modified_files, 'basics.sh')
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Clone PR branch if this is triggered on a PR
@@ -39,5 +37,7 @@ jobs:
         
     - name: run basics.sh
       id: basics-install
+      # run this job only if the basics.sh file has been changed
+      if: contains(steps.changed-files.outputs.modified_files, 'basics.sh')
       run: |
         /bin/bash $GITHUB_WORKSPACE/code_folder/basics.sh


### PR DESCRIPTION
- The run basics step in the script will only execute if the basics.sh file has been altered. This is to avoid unnecessary checking of the install when other elements of the cookie_cutter template are altered and the basics.sh has remained the same