### PR TITLE
Tidy up project template, correct environment and auto-formatting issues

### DIFF
--- a/basics.sh
+++ b/basics.sh
@@ -77,11 +77,10 @@
     echo "export LDFLAGS=-L/usr/local/opt/bzip2/lib" >> ~/.zshrc
     echo "export CPPFLAGS=-I/usr/local/opt/bzip2/include" >> ~/.zshrc
     echo "\n-> installing from pipx:"
-    echo "   pipenv pipenv-pipes pipenv-setup pre-commit"
+    echo "   pipenv pipenv-pipes pre-commit"
     {
         pipx install pipenv
         pipx install pipenv-pipes
-        pipx install pipenv-setup
         pipx install pre-commit
     } && echo "finished installing python tools"
     source ~/.zshrc

--- a/the_basics.md
+++ b/the_basics.md
@@ -107,10 +107,8 @@ pipx install pipenv
 #### Install pipenv bolt-on functions
 pipenv-pipes helps you to activate pipenv environments, automatically change to the environment working directory.
 From anywhere, simply type `pipes` to see your environments, select one and enter.
-pipenv-setup helps you to keep your environment and your `setup.py` file in sync via `pipenv-setup sync`
 ```zsh
 pipx install pipenv-pipes
-pipx install pipenv-setup
 ```
 
 #### Set up pre-commit and pre-push hooks

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
   rev: v0.990
   hooks:
       - id: mypy
-        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports]
+        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports, --disallow-untyped-defs]
         require_serial: true
 
 - repo: local

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -27,25 +27,25 @@ repos:
     - id: autoflake
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
       - id: flake8
-  types: [ python ]
-  exclude: 'setup.py'
-  additional_dependencies: [
-          'flake8-blind-except',
-          'flake8-commas',
-          'flake8-comprehensions',
-          'flake8-deprecated',
-          'flake8-docstrings',
-          'flake8-meiqia',
-          'flake8-mutable',
-          'flake8-pep3101',
-          'flake8-quotes',
-          'flake8-string-format',
-          'flake8-tidy-imports',
-  ]
+        types: [python]
+        exclude: setup.py
+        additional_dependencies: [
+            'flake8-blind-except',
+            'flake8-commas',
+            'flake8-comprehensions',
+            'flake8-deprecated',
+            'flake8-docstrings',
+            'flake8-meiqia',
+            'flake8-mutable',
+            'flake8-pep3101',
+            'flake8-quotes',
+            'flake8-string-format',
+            'flake8-tidy-imports',
+        ]
 
 - repo: https://github.com/timothycrosley/isort
   rev: 5.10.1
@@ -57,6 +57,13 @@ repos:
   hooks:
       - id: black
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.990
+  hooks:
+      - id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports]
+        require_serial: true
+
 - repo: local
   hooks:
   - id: add inits
@@ -67,26 +74,12 @@ repos:
         touch $DIR/__init__.py;
       done"
 
-  - id: mypy
-    name: mypy
-    language: system
-    entry: pipenv run mypy
-    types: [python]
-    require_serial: true
 
 - repo: https://github.com/anmut-consulting/pipenv-setup
-  rev: v3.1.4
+  rev: v3.1.5
   hooks:
   - id: pipenv-setup-sync
-    name: "pipenv-setup sync with pipfile"
     stages: [push]
-    language: system
-    entry: pipenv run pipenv-setup sync --pipfile
-    pass_filenames: false
 
   - id: pipenv-setup-check
-    name: "pipenv-setup check"
     stages: [push]
-    language: system
-    entry: pipenv run pipenv-setup check
-    pass_filenames: false

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -34,8 +34,6 @@ repos:
         types: [python]
         exclude: setup.py
         additional_dependencies: [
-            'flake8-blind-except',
-            'flake8-commas',
             'flake8-comprehensions',
             'flake8-deprecated',
             'flake8-docstrings',
@@ -46,11 +44,13 @@ repos:
             'flake8-string-format',
             'flake8-tidy-imports',
         ]
+        args: ['--exclude=docs/conf.py', '--ignore=E203,E266,E501,W503', '--max-line-length=88', '--max-complexity=18', '--select=B,C,E,F,W,T4']
 
 - repo: https://github.com/timothycrosley/isort
   rev: 5.10.1
   hooks:
       - id: isort
+        args: ['--multi-line=3', '--trailing-comma', '--force-grid-wrap=0', '--use-parentheses', '--line-length=88', '--skip=docs/conf.py']
 
 - repo: https://github.com/psf/black
   rev: 22.3.0
@@ -61,7 +61,7 @@ repos:
   rev: v0.990
   hooks:
       - id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
+        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports]
         require_serial: true
 
 - repo: local
@@ -73,7 +73,6 @@ repos:
       "for DIR in $(find \"./{{ cookiecutter.repo_name }}\" -type d); do
         touch $DIR/__init__.py;
       done"
-
 
 - repo: https://github.com/anmut-consulting/pipenv-setup
   rev: v3.1.5

--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -9,11 +9,7 @@ python_version = "{{ cookiecutter.python_version }}"
 [packages]
 
 [dev-packages]
-black = "*"
 bump2version = "*"
-flake8 = "*"
-isort = "*"
-mypy = "*"
 pre-commit = "*"
 pytest = "*"
 pytest-cov = "*"
@@ -23,8 +19,6 @@ sphinx-rtd-theme = "*"
 jupyter = "*"
 jupyterlab = "*"
 ipython = "*"
-pipenv-setup = { git = 'https://github.com/anmut-consulting/pipenv-setup.git', ref = 'requirementslib_update'}
-
 
 [scripts]
 init = "pipenv run $SHELL scripts/init.sh"

--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -16,7 +16,6 @@ pytest-cov = "*"
 sphinx = "*"
 sphinx-autoapi = "*"
 sphinx-rtd-theme = "*"
-jupyter = "*"
 jupyterlab = "*"
 ipython = "*"
 

--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -23,7 +23,7 @@ sphinx-rtd-theme = "*"
 jupyter = "*"
 jupyterlab = "*"
 ipython = "*"
-pipenv-setup = { git = 'https://github.com/anmut-consulting/pipenv-setup.git', ref = 'v3.1.4'}
+pipenv-setup = { git = 'https://github.com/anmut-consulting/pipenv-setup.git', ref = 'requirementslib_update'}
 
 
 [scripts]

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -20,24 +20,6 @@ replace = version: {new_version}
 [bdist_wheel]
 universal = 1
 
-[flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 88
-max-complexity = 18
-select = B,C,E,F,W,T4
-
-[isort]
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88
-skip = docs/conf.py
-
-[mypy]
-files = {{cookiecutter.repo_name}}, tests
-ignore_missing_imports = true
-
 [aliases]
 # Define setup.py command aliases here
 test = pytest


### PR DESCRIPTION
This template has a number of issues that are addressed as follows:

- A newer version of pipenv-setup is referenced, which addresses some issues with requirementslib, vistir and pre-commit hooks (as seen in [this closed pull request in pipenv-setup](https://github.com/anmut-consulting/pipenv-setup/pull/4)). All references to the stock version of pipenv-setup are removed, from the basics.sh install script and the documentation included with the template. Additionally, a bug to do with syncing is fixed (see [this issue in the upstream pipenv-setup](https://github.com/Madoshakalaka/pipenv-setup/issues/33))
- All pre-commit hooks are now loaded from remote repositories, with version numbers specified for repeatability. This includes formatting packages (e.g. black, mypy, flake) that have been relocated to pre-commit hooks, so the Pipfile only contains packages relevant to the actual function of the code
- Flake8 appears to be have been configured incorrectly in .pre-commit-config.yaml with the wrong indentation being used, this has been rectified. Additionally, the Gitlab mirror of Flake8 appears to no longer be accessible without approval, so this has been transferred to the official Github repository. The flake8-blind-except and flake8-commas plugins have been removed as they are no longer required. 
- Non-necessary dev packages have been removed from the pipfile (jupyter)

Here are some caveats with these changes:
- There is a potential issue with moving mypy from local to remote running, due to the hooks running in an isolated virtual environment that is independent from the one used to run the project code (see [this page](https://jaredkhan.com/blog/mypy-pre-commit) for more information, in particular [here](https://jaredkhan.com/blog/mypy-pre-commit#problem-running-in-an-isolated-virtualenv)). We have addressed this in part by using the following options with mypy: `--install-types, --non-interactive, --ignore-missing-imports`
- There is an issue where settings can be read from the `setup.cfg` file, even when the formatting tools are being setup and run as pre-commit hooks. This is something to be aware of, and potentially look at in the future