### PR TITLE
Update pre-commit configuration 

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
     args: ['--allow-missing-credentials']
   - id: detect-private-key
   - id: end-of-file-fixer
-    exclude: 'docs/|setup.cfg'
+    exclude: docs/|setup.cfg
   - id: trailing-whitespace
-    exclude: 'docs/|setup.cfg'
+    exclude: docs/|setup.cfg
 
 - repo: https://github.com/myint/docformatter
   rev: v1.4
@@ -32,7 +32,7 @@ repos:
   hooks:
       - id: flake8
         types: [python]
-        exclude: 'setup.py'
+        exclude: setup.py
         additional_dependencies: [
             'flake8-blind-except',
             'flake8-comprehensions',

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -20,20 +20,18 @@ repos:
   rev: v1.4
   hooks:
   - id: docformatter
-    exclude: docs/|setup.py|tests/
 
 - repo: https://github.com/humitos/mirrors-autoflake
   rev: v1.1
   hooks:
     - id: autoflake
-      exclude: docs/|setup.py|tests/
+      exclude: setup.py
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
       - id: flake8
-        exclude: docs/|setup.py|tests/
         types: [python]
         additional_dependencies: [
             'flake8-blind-except',
@@ -53,21 +51,19 @@ repos:
   rev: 5.10.1
   hooks:
       - id: isort
-        exclude: docs/|setup.py|tests/
         args: ['--multi-line=3', '--trailing-comma', '--force-grid-wrap=0', '--use-parentheses', '--line-length=88']
 
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
       - id: black
-        exclude: docs/|setup.py|tests/
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.990
   hooks:
       - id: mypy
         exclude: docs/|setup.py|tests/
-        args: ['--no-strict-optional', '--install-types', '--non-interactive', '--ignore-missing-imports', '--disallow-untyped-defs']
+        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports, --disallow-untyped-defs]
         require_serial: true
 
 - repo: local
@@ -76,7 +72,7 @@ repos:
     name: add_inits
     language: system
     entry: bash -c \
-      "for DIR in $(find \"./{{ cookiecutter.repo_name }}\" -type d); do
+      "for DIR in $(find \"./event_analysis\" -type d); do
         touch $DIR/__init__.py;
       done"
 

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -20,20 +20,23 @@ repos:
   rev: v1.4
   hooks:
   - id: docformatter
+    exclude: docs/|setup.py|tests/
 
 - repo: https://github.com/humitos/mirrors-autoflake
   rev: v1.1
   hooks:
     - id: autoflake
+      exclude: docs/|setup.py|tests/
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
       - id: flake8
+        exclude: docs/|setup.py|tests/
         types: [python]
-        exclude: setup.py
         additional_dependencies: [
+            'flake8-blind-except'
             'flake8-comprehensions',
             'flake8-deprecated',
             'flake8-docstrings',
@@ -44,24 +47,27 @@ repos:
             'flake8-string-format',
             'flake8-tidy-imports',
         ]
-        args: ['--exclude=docs/conf.py', '--ignore=E203,E266,E501,W503', '--max-line-length=88', '--max-complexity=18', '--select=B,C,E,F,W,T4']
+        args: ['--ignore=E203,E266,E501,W503', '--max-line-length=88', '--max-complexity=18', '--select=B,C,E,F,W,T4']
 
 - repo: https://github.com/timothycrosley/isort
   rev: 5.10.1
   hooks:
       - id: isort
-        args: ['--multi-line=3', '--trailing-comma', '--force-grid-wrap=0', '--use-parentheses', '--line-length=88', '--skip=docs/conf.py']
+        exclude: docs/|setup.py|tests/
+        args: ['--multi-line=3', '--trailing-comma', '--force-grid-wrap=0', '--use-parentheses', '--line-length=88']
 
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
       - id: black
+        exclude: docs/|setup.py|tests/
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.990
   hooks:
       - id: mypy
-        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports, --disallow-untyped-defs]
+        exclude: docs/|setup.py|tests/
+        args: ['--no-strict-optional', '--install-types', '--non-interactive', '--ignore-missing-imports', '--disallow-untyped-defs']
         require_serial: true
 
 - repo: local

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -71,9 +71,10 @@ repos:
     name: add_inits
     language: system
     entry: bash -c \
-      "for DIR in $(find \"./event_analysis\" -type d); do
+      "for DIR in $(find \"./{{ cookiecutter.repo_name }}\" -type d); do
         touch $DIR/__init__.py;
       done"
+
 
 - repo: https://github.com/anmut-consulting/pipenv-setup
   rev: v3.1.5

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         exclude: docs/|setup.py|tests/
         types: [python]
         additional_dependencies: [
-            'flake8-blind-except'
+            'flake8-blind-except',
             'flake8-comprehensions',
             'flake8-deprecated',
             'flake8-docstrings',

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -75,7 +75,6 @@ repos:
         touch $DIR/__init__.py;
       done"
 
-
 - repo: https://github.com/anmut-consulting/pipenv-setup
   rev: v3.1.5
   hooks:

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
   rev: v1.1
   hooks:
     - id: autoflake
-      exclude: setup.py
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
 - repo: https://github.com/PyCQA/flake8

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
   hooks:
       - id: flake8
         types: [python]
+        exclude: 'setup.py'
         additional_dependencies: [
             'flake8-blind-except',
             'flake8-comprehensions',

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -24,7 +24,7 @@ import sys
 
 try:
     import {{cookiecutter.repo_name}}
-except Exception: # noqa: B902
+except Exception:  # noqa: B902
     sys.path.insert(0, os.path.abspath(".."))
     import {{cookiecutter.repo_name}}
 

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -24,7 +24,7 @@ import sys
 
 try:
     import {{cookiecutter.repo_name}}
-except Exception:
+except Exception: # noqa: B902
     sys.path.insert(0, os.path.abspath(".."))
     import {{cookiecutter.repo_name}}
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -13,9 +13,9 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-setup_requirements = ["pytest-runner"]  # type: List[str]
+setup_requirements = ["pytest-runner"]
 
-test_requirements = ["pytest"]  # type: List[str]
+test_requirements = ["pytest"]
 
 {%- set license_classifiers = {
     "MIT license": "License :: OSI Approved :: MIT License",

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -3,8 +3,6 @@
 
 """The setup script."""
 
-from typing import List
-
 from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:


### PR DESCRIPTION
The flake8-blind-except test has been re-added to Flake8, and the setup.py file and the setup and test directories have been ignored in the relevant pre-commit hooks.