### PR TITLE
Update pre-commit configuration with latest version of isort

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: docs/|setup.cfg
 
 - repo: https://github.com/myint/docformatter
-  rev: v1.4
+  rev: v1.5.0 # v1.5.1 gives unwanted formatting behaviour relating to https://github.com/PyCQA/docformatter/issues/124, please use v1.5.0 until a new stable release patches this
   hooks:
   - id: docformatter
 

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         args: ['--ignore=E203,E266,E501,W503', '--max-line-length=88', '--max-complexity=18', '--select=B,C,E,F,W,T4']
 
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
       - id: isort
         args: ['--multi-line=3', '--trailing-comma', '--force-grid-wrap=0', '--use-parentheses', '--line-length=88']


### PR DESCRIPTION
isort 5.10.1 recently broke due to an issue with with one of its internal dependencies, poetry. This dependency changed the format of its internal configuration file, leading to a breakage within isort. Therefore, isort has been upgraded to version 5.12.0 which fixes this issue.

For more information on this breakage, see [this stackoverflow post](https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co), [this issue on Github](https://github.com/PyCQA/isort/issues/2077) and [this stackoverflow post](https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co).