### PR TITLE
Update basics.sh with working environment variables

### DIFF
--- a/basics.sh
+++ b/basics.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 (
-    echo "\n-> installing xcode: \n"
+    printf "\n-> installing xcode: \n\n"
     if ! [[ -x $(xcode-select -p) ]];
     then 
         xcode-select -s /Applications/Xcode.app/Contents/Developer \
@@ -8,21 +8,21 @@
             && xcode-select -s /Applications/Xcode.app/Contents/Developer) \
         && xcodebuild -license
     fi
-    echo "\n-> xcode installed <-\n"
+    printf "\n-> xcode installed <-\n\n"
 
-    echo "\n-> installing xcode cli: \n"
+    printf "\n-> installing xcode cli: \n\n"
     xcode-select --install \
-    && echo "\n-> xcode cli installed <-\n" \
-    || echo " "
-    echo "\n-> installing homebrew: \n"
+    && printf "\n-> xcode cli installed <-\n\n" \
+    || printf "\n"
+    printf "\n-> installing homebrew: \n\n"
     {
         if ! [[ $(brew --version) ]];
         then
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         fi \
-        && echo "\n-> homebrew installed <-\n" \
-        && echo "\n-> installing from brew:" \
-        && echo "     zsh python3 cmake git htop openssl readline sqlite3 tree unar xz zlib pipx pyenv\n" \
+        && printf "\n-> homebrew installed <-\n\n" \
+        && printf "\n-> installing from brew:\n" \
+        && printf "     zsh python3 cmake git htop openssl readline sqlite3 tree unar xz zlib pipx pyenv\n\n" \
         && {
           brew install zsh
           brew install python3
@@ -47,23 +47,23 @@
 #          brew tap heroku/brew && brew install heroku
         }
     } \
-    && echo "\n-> packages installed from brew! <-\n"
+    && printf "\n-> packages installed from brew! <-\n\n"
     touch ~/.zshrc
     if ! grep -Fxq 'export PYENV_ROOT="$HOME/.pyenv"' ~/.zshrc
     then
-        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+        printf 'export PYENV_ROOT="$HOME/.pyenv"\n' >> ~/.zshrc
     fi
     if ! grep -Fxq 'export PATH="$PYENV_ROOT:$PATH"' ~/.zshrc
     then
-        echo 'export PATH="$PYENV_ROOT:$PATH"' >> ~/.zshrc
+        printf 'export PATH="$PYENV_ROOT:$PATH"\n' >> ~/.zshrc
     fi
     if ! grep -Fxq 'if command -v pyenv 1>/dev/null 2>&1; then' ~/.zshrc
     then
-        echo 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+        printf 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi\n' >> ~/.zshrc
     fi
     source ~/.zshrc
-    echo "\n-> installing software from homebrew casks:"
-    echo "this is a minimal list to get you started"
+    printf "\n-> installing software from homebrew casks:\n"
+    printf "this is a minimal list to get you started\n"
     {
         brew install --cask docker
         brew install --cask dbeaver-community
@@ -71,26 +71,32 @@
         brew install --cask the-unarchiver
         brew install --cask drawio
         pipx ensurepath && source ~/.zshrc
-    } && echo "\n-> installation from homebrew casks successfull <-\n"
-    echo "Adding compiler flags for bzip2"
-    echo "export LDFLAGS=-L/usr/local/opt/bzip2/lib" >> ~/.zshrc
-    echo "export CPPFLAGS=-I/usr/local/opt/bzip2/include" >> ~/.zshrc
-    echo "\n-> installing from pipx:"
-    echo "   pipenv pipenv-pipes pre-commit"
+    } && printf "\n-> installation from homebrew casks successfully <-\n\n"
+    printf "Adding compiler flags for bzip2\n"
+    if ! grep -Fxq 'export LDFLAGS=-L/usr/local/opt/bzip2/lib' ~/.zshrc
+    then
+        printf "export LDFLAGS=-L/usr/local/opt/bzip2/lib\n" >> ~/.zshrc
+    fi
+    if ! grep -Fxq 'export CPPFLAGS=-I/usr/local/opt/bzip2/include' ~/.zshrc
+        then
+    printf "export CPPFLAGS=-I/usr/local/opt/bzip2/include\n" >> ~/.zshrc
+    fi
+    printf "\n-> installing from pipx:\n"
+    printf "   pipenv pipenv-pipes pre-commit\n"
     {
         pipx install pipenv
         pipx install pipenv-pipes
         pipx install pre-commit
-    } && echo "finished installing python tools"
+    } && printf "finished installing python tools\n"
     source ~/.zshrc
-    echo "\n-> pipx installations complete <-" \
-    && echo "\n-> configuring git to run pre-commit hooks, when found, automatically:" \
+    printf "\n-> pipx installations complete <-\n" \
+    && printf "\n-> configuring git to run pre-commit hooks, when found, automatically:\n" \
     && git config --global init.templateDir ~/.git-template \
     && pre-commit init-templatedir ~/.git-template -t pre-commit -t pre-push \
-    && echo "\n-> pre-commit configured <-" ) \
+    && printf "\n-> pre-commit configured <-\n" ) \
 && (
-    echo "\n"
-    echo "================== INSTALLATION COMPLETE! =================="
-    echo "CLOSE ALL TERMINAL WINDOWS AND REOPEN TO ENSURE CORRECT PATH"
-    echo "================== INSTALLATION COMPLETE! =================="
-    echo "\n" ) && echo 'tell application "Terminal" to close (every window)' && exit 0 || exit 1
+    printf "\n\n"
+    printf "================== INSTALLATION COMPLETE! ==================\n"
+    printf "CLOSE ALL TERMINAL WINDOWS AND REOPEN TO ENSURE CORRECT PATH\n"
+    printf "================== INSTALLATION COMPLETE! ==================\n"
+    printf "\n\n" ) && printf 'tell application "Terminal" to close (every window)\n' && exit 0 || exit 1

--- a/basics.sh
+++ b/basics.sh
@@ -66,7 +66,6 @@
     echo "this is a minimal list to get you started"
     {
         brew install --cask docker
-        brew install --cask dashlane
         brew install --cask dbeaver-community
         brew install --cask sublime-text
         brew install --cask the-unarchiver


### PR DESCRIPTION
basics.sh currently uses the echo command to insert lines into the .zshrc file, which has problems with handling escaped characters.  This causes problems when echoing multi-line strings in the script such as `'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi\n' >> ~/.zshrc`, which are displayed and handled as one line, even though the string is actually 3 lines.

For reference, the desired output is:
```
if command -v pyenv 1>/dev/null 2>&1; then
  eval "$(pyenv init -)"
fi
```

Therefore, all instances of echo have been replaced with printf, which properly handles escaped characters. In addition, checks have been added to bzip2 flag insertion to ensure they are added only once to .zshrc.

Furthermore, dashlane has been removed from the script as it is no longer available via a brew cask. 