### PR TITLE
Fix example Python source file typing

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
@@ -22,7 +22,7 @@ def fib(n: int) -> int:
         return fib(n - 1) + fib(n - 2)
 
 
-def fib_ratio(n):
+def fib_ratio(n) -> float:
     """Fibonacci Ratio Generator.
 
     This will give you the n'th ratio in the Fibonacci sequence

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
@@ -22,7 +22,7 @@ def fib(n: int) -> int:
         return fib(n - 1) + fib(n - 2)
 
 
-def fib_ratio(n) -> float:
+def fib_ratio(n: int) -> float:
     """Fibonacci Ratio Generator.
 
     This will give you the n'th ratio in the Fibonacci sequence


### PR DESCRIPTION
The `fib_ratio` function in the `{{cookiecutter.repo_name}}.py` source file does not pass our suite of MyPy tests, which means any project generated from this template will require this problematic example source file to be removed or corrected.

This simple change solves the issue by adding type annotations to the input variable and by adding a return type, so the project now passes all tests in an unmodified state.