### PR TITLE
pipenv-setup external dependency sync fix 

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
   hooks:
       - id: mypy
         exclude: docs/|setup.py|tests/
-        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports, --disallow-untyped-defs]
+        args: ['--no-strict-optional', '--install-types', '--non-interactive', '--ignore-missing-imports', '--disallow-untyped-defs']
         require_serial: true
 
 - repo: local

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -81,6 +81,8 @@ repos:
   hooks:
   - id: pipenv-setup-sync
     stages: [push]
+    args: ['--process-dependency-links']
 
   - id: pipenv-setup-check
     stages: [push]
+    args: ['--lockfile']

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -81,8 +81,7 @@ repos:
   hooks:
   - id: pipenv-setup-sync
     stages: [push]
-    args: ['--process-dependency-links']
+    args: ['--pipfile', '--process-dependency-links']
 
   - id: pipenv-setup-check
     stages: [push]
-    args: ['--lockfile']

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
   hooks:
       - id: mypy
         exclude: docs/|setup.py|tests/
-        args: ['--no-strict-optional', '--install-types', '--non-interactive', '--ignore-missing-imports', '--disallow-untyped-defs']
+        args: [--no-strict-optional, --install-types, --non-interactive, --ignore-missing-imports, --disallow-untyped-defs]
         require_serial: true
 
 - repo: local


### PR DESCRIPTION
When installing an internal Anmut module into another project, the pipenv-setup hook will fail on trying to push to a remote. This is for 2 reasons:
- In the current setup, the sync hook is configured to sync with the `Pipfile.lock` file, but the check hook is configured to check setup.py against the `Pipfile`. Since external repositories are referenced in the `Pipfile` by version number, but our internal private repositories are referenced by commit hash in `Pipfile.lock`, this check will always fail e.g. `anmut:repository@v0.0.3` vs `anmut:repository@fdf4fc `
- pipenv-setup is not configured to sync the `dependency_links` list in `setup.py`, which causes the check hook to fail. 

To solve these issues, pipenv-setup has been configured to both sync and check `setup.py` against the `Pipfile` file, so we benefit from semantic versioning rather than specific locked versions of dependencies. Additionally, pipenv-setup has been configured to process the `dependency_links` list in `setup.py`.