### PR TITLE
collect_ignore param not recognised

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -27,4 +27,4 @@ test = pytest
 [tool:pytest]
 testpaths = tests/
 norecursedirs = env venv .env .venv
-collect_ignore = ['setup.py']
+addopts = --ignore=setup.py


### PR DESCRIPTION
The collect_ignore config option in setup.cfg is not recognised by pytest and would therefore raise a warning when running tests. Now replaced with addopts which works as expected.