### PR TITLE
Remove redundant pipenv dependency synchronisation from pre-commit workflow

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/test.yml
@@ -13,19 +13,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: webfactory/ssh-agent@v0.4.1
-      with:
-        ssh-private-key: ${{ '{{' }} secrets.SSH_PRIVATE_KEY {{ '}}' }}
-
     - name: Setup Python
       uses: actions/setup-python@master
       with:
           python-version: {{ cookiecutter.python_version }}
-
-    - name: Install dependencies with pipenv
-      run: |
-          pip install pipenv
-          pipenv sync --dev
 
     - uses: pre-commit/action@v2.0.0
       with:


### PR DESCRIPTION
Currently, we are experiencing problems with Github Actions involving dependencies that are located in private Anmut repositories not resolving correctly because the virtual machine running these tests does not have the SSH credentials required to authenticate itself.

We have a number of Github Actions configured to run on our repositories upon certain actions, such as merging code into the master branch. Two of these actions are combined within the "Test" workflow, defined within `test.yml` source file, namely: 
- `pre-commit` (lines 9-28):  runs our configured pre-commit hooks such as Flake8, Autoflake and Mypy against the source files in the repository, ensuring that even if tests have been disabled locally they are run against the source files at least once
- `test` (lines 30-67):  runs the written Pytest tests and fixtures and ensures that these all pass, and that 100% code coverage is achieved

Both actions are currently configured to install all dependencies listed in the `Pipfile`, then run their respective tests. In the case of `pre-commit`, this was required when pre-commit hooks were installed as local / system packages within each repository. However, only the `test` workflow is has an SSH key configured for the web agent. This means that the `pre-commit` action will always fail on a repository with dependencies hosted on private repositories, regardless of whether or not the hooks themselves will actually pass. 

Therefore, this pull request removes the pipenv dependency synchronisation from the `pre-commit` test as pre-commit hooks are now all fetched and installed into their own environments rather than the pipenv environment.

We have not encountered noticed this configuration issue before because our repositories that have private dependencies are based on older versions of our cookiecutter template, where the `pre-commit` test does not sync with the Pipfile before running.
