### PR TITLE
Install ipykernel for the current user (not system-wide)

### DIFF
--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -29,5 +29,5 @@ coverage = "pipenv run pytest --cov --cov-fail-under=100 --cov-report term-missi
 tests = "pipenv run pre-commit run -a"
 test = "pipenv run pytest"
 make_docs = "pipenv run $SHELL scripts/make_docs.sh"
-create_ipykernel = "pipenv run python -m ipykernel install --name {{ cookiecutter.repo_name }} --display-name \"{{ cookiecutter.project_name }}\" "
+create_ipykernel = "pipenv run python -m ipykernel install --user --name {{ cookiecutter.repo_name }} --display-name \"{{ cookiecutter.project_name }}\" "
 remove_ipykernel = "pipenv run jupyter kernelspec remove {{ cookiecutter.repo_name }} "


### PR DESCRIPTION
When running `pipenv run python -m ipykernel install --name {{ cookiecutter.repo_name }} --display-name \"{{ cookiecutter.project_name }}\" ` for the script  `create_ipykernel` in the pipfile, we get an error `[Errno 13] Permission denied: '/usr/local/share/jupyter'`.

As hinted by #https://github.com/Calysto/matlab_kernel/issues/68#issuecomment-257162116, the solution is to add a `--user` option in the command.

The `--user ` option is specified when installing IPython kernel for the current user instead of trying to install for the whole system, and therefore needing admin privileges.

<img width="561" alt="Screenshot 2023-05-31 at 17 45 28" src="https://github.com/anmut-consulting/pipenv-cookiecutter/assets/127394133/2ab9a7e9-2c66-4dd3-89ac-5be1388ad047">

Since all Anmut laptop's personal users do not have admin privileges, the pipfile needs to be changed by adding the `--user` option to only install ipykernel for the current user.