### PR TITLE
Fix homebrew install

### DIFF
--- a/basics.sh
+++ b/basics.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Check if running on MacOS, if not, abort with error exit code
 if [[ $(uname) != "Darwin" ]]

--- a/basics.sh
+++ b/basics.sh
@@ -16,6 +16,7 @@
     && printf "\n-> xcode cli installed <-\n\n" \
     || printf "\n"
 
+    printf "\n-> installing homebrew: \n\n"
     {
         # Check if brew is installed, if not, download the install script using curl
         if ! [[ $(brew --version) ]];

--- a/basics.sh
+++ b/basics.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
-
-# Check if running on MacOS, if not, abort with error exit code
-if [[ $(uname) != "Darwin" ]]
-then
-  printf 'This script must be run on a MacOS machine. Exiting!\n'
-  exit 1
-fi
-
 (
     printf "\n-> installing xcode: \n\n"
     # Check if xcode configured and if not set it up on your machine

--- a/basics.sh
+++ b/basics.sh
@@ -72,10 +72,10 @@
 
           # Check brew installation and adding to path was successful
           if ! [[ $(brew --version) ]]; then
-            printf "Adding Homebrew to path in session was unsuccessful. Exiting!\n"
+            printf "Adding Homebrew to path in session was unsuccessful. Please contact the owner of the script for help!\n"
             exit 1;
           else
-            printf "Homebrew is now in path for this session.\n"
+            printf "Homebrew is now in path for this session. Continuing...\n"
           fi
 
         fi \

--- a/basics.sh
+++ b/basics.sh
@@ -61,10 +61,11 @@ fi
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           printf "Brew binaries installed.\n"
 
+          printf "\nAdding brew shell environment configuration command to '%s'.\n" "${config_file}"
+          printf "This ensures brew environment variables are configured correctly every terminal session.\n"
+
           # Create eval command to be outputted into shell configuration file
           eval_command="eval \"\$(${installation_dir}/bin/brew shellenv)\""
-          printf "Adding brew shell environment configuration command to '%s'.\n" "${config_file}"
-          printf "This ensures brew environment variables are configured correctly every terminal session.\n"
 
           # Ensure that we only add the eval command if command not already present in the config file
           # Then add the command to the shell config file. This adds brew to path
@@ -79,10 +80,11 @@ fi
 
           # Check brew installation and adding to path was successful
           if ! [[ $(brew --version) ]]; then
-            printf "\nAdding brew to path was unsuccessful. Exiting!\n"
+            printf "Adding brew to path in session was unsuccessful. Exiting!\n"
             exit 1;
+          else
+            printf "Brew is now in path for this session.\n"
           fi
-
 
         fi \
         && printf "\n-> homebrew installed and configured <-\n\n" \

--- a/basics.sh
+++ b/basics.sh
@@ -16,14 +16,19 @@
     && printf "\n-> xcode cli installed <-\n\n" \
     || printf "\n"
 
-    printf "\n-> installing homebrew: \n\n"
     {
-        # Check if brew is installed, if not, download the install script using
-        # curl, run it and return to this script after the installation is
-        # complete.
+        # Check if brew is installed, if not, download the install script using curl
         if ! [[ $(brew --version) ]];
         then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # if running on an Apple Silicon-based machine, we must add to PATH manually
+          UNAME_MACHINE="$(/usr/bin/uname -m)"
+          if [[ "${UNAME_MACHINE}" == "arm64" ]]
+          then
+            printf 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+          fi
         fi \
         && printf "\n-> homebrew installed <-\n\n" \
         && printf "\n-> installing from brew:\n" \

--- a/basics.sh
+++ b/basics.sh
@@ -18,12 +18,12 @@
 
     printf "\n-> installing homebrew: \n\n"
     {
-        # Check if brew is installed, if not, download the install script using curl
+        # Check if brew is installed, if not, downloads the install script using curl and runs
         if ! [[ $(brew --version) ]];
         then
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-          # if running on an Apple Silicon-based machine, we must add to PATH manually
+          # if running on an Apple silicon-based machine, we must add to PATH manually
           UNAME_MACHINE="$(/usr/bin/uname -m)"
           if [[ "${UNAME_MACHINE}" == "arm64" ]]
           then

--- a/basics.sh
+++ b/basics.sh
@@ -29,7 +29,7 @@ fi
         # Check if brew is installed, if not, download the install script using curl and run
         if ! [[ $(brew --version) ]];
         then
-          printf "Brew not currently installed, trying installation now."
+          printf "Brew not currently installed, trying installation now.\n"
 
           # Check what type of shell is configured, and set the appropriate shell config
           # file
@@ -59,7 +59,7 @@ fi
 
           # Download brew install script using curl and run.
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          printf "Brew binaries installed."
+          printf "Brew binaries installed.\n"
 
           # Create eval command to be outputted into shell configuration file
           eval_command="eval \"\$(${installation_dir}/bin/brew shellenv)\""

--- a/basics.sh
+++ b/basics.sh
@@ -29,7 +29,7 @@ fi
         # Check if brew is installed, if not, download the install script using curl and run
         if ! [[ $(brew --version) ]];
         then
-          printf "Brew not currently installed, trying installation now.\n"
+          printf "Homebrew not currently installed, trying installation now.\n"
 
           # Check what type of shell is configured, and set the appropriate shell config
           # file
@@ -40,7 +40,7 @@ fi
           elif [[ "${SHELL_TYPE}" == "/bin/bash" ]]; then
             config_file="${HOME}/.bash_profile"
           else
-            printf 'Your shell is not zsh or bash! Install Brew manually and rerun this script. Exiting!\n'
+            printf 'Your shell is not zsh or bash! Install Homebrew manually and rerun this script. Exiting!\n'
             exit 1
           fi
 
@@ -53,13 +53,13 @@ fi
           elif [[ "${MACHINE_ARCHITECTURE}" == "x86_64" ]]; then
             installation_dir='/usr/local'
           else
-            printf 'The processor architecture of your Mac is not supported by this script. Install Brew manually and rerun this script. Exiting!\n'
+            printf 'The processor architecture of your Mac is not supported by this script. Install Homebrew manually and rerun this script. Exiting!\n'
             exit 1
           fi
 
           # Download brew install script using curl and run.
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          printf "Brew binaries installed.\n"
+          printf "Homebrew binaries installed.\n"
 
           printf "\nAdding brew shell environment configuration command to '%s'.\n" "${config_file}"
           printf "This ensures brew environment variables are configured correctly every terminal session.\n"
@@ -80,10 +80,10 @@ fi
 
           # Check brew installation and adding to path was successful
           if ! [[ $(brew --version) ]]; then
-            printf "Adding brew to path in session was unsuccessful. Exiting!\n"
+            printf "Adding Homebrew to path in session was unsuccessful. Exiting!\n"
             exit 1;
           else
-            printf "Brew is now in path for this session.\n"
+            printf "Homebrew is now in path for this session.\n"
           fi
 
         fi \


### PR DESCRIPTION
Currently, the `basics.sh` script contains a bug such that an error will occur if the installation of package manager Homebrew is required. This is because the Homebrew installation location is not currently added to the PATH environment variable when installed. As a result, the script will install brew if it is not present, but since its installation location is not added to PATH, the commands following the installation (e.g. `brew install htop`) will fail with an error (`zsh: command not found: brew`).

The reason that the script works on older Intel Mac machines but not on the newer Apple Silicone ones is because Homebrew has a different installation location on Intel and Apple Silicone Macs (see the [Brew FAQ page](
https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location) and [this excellent blog post](https://earthly.dev/blog/homebrew-on-m1/) for more information).

The old installation path (`/user/local`) is _already_ in the PATH variable _by default_ on Mac OS. However, the new installation path (`/opt/homebrew`) is **NOT**. Therefore, if installing on an Apple Silicone machine, we must add this location to PATH for Homebrew to be found.

Homebrew provides a way to do this, using the `brew shellenv` command, which outputs the required brew shell environment variables to the console, including modifying the PATH variable to contain the current brew installation directory:

```
export HOMEBREW_PREFIX="/opt/homebrew";
export HOMEBREW_CELLAR="/opt/homebrew/Cellar";
export HOMEBREW_REPOSITORY="/opt/homebrew";
export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}";
export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:";
export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}";
```

Using the `eval` command, we can run these export commands in the shell and therefore configure brew to work: `eval "$([installation_directory]/brew shellenv)"`.

The Homebrew installer currently instructs the user to run the following commands after it completes:
```
eval "$(/opt/homebrew/bin/brew shellenv)"
echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
```
(The above example is for zsh and Apple Silicon Macs). Adding this eval command to the `.zprofile` file means that brew is configured properly every time a terminal session is opened. However, the installer does not add this line to the shell configuration file automatically.

Therefore, this PR aims to solve the issue by intelligently checking both the processor architecture and shell type of the machine, adding the eval command with the correct installation directory to the appropriate shell configuration file, and then adding brew to the path for the current session. This allows the `basics.sh` script to install brew, and subsequent software through brew, without error. Functionality to do this on Intel Macs has also been included because while the brew installation directory is already in PATH, the required environment variables are still missing, as outlined above.

Additionally, the shebang at the top of the script has been corrected to specify bash, rather than sh. This is because bash-specific syntax is used in the script (e.g. the if statement structure).