### PR TITLE
Update the autoflake pre-commit hook

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
   hooks:
   - id: docformatter
 
-- repo: https://github.com/humitos/mirrors-autoflake
-  rev: v1.1
+- repo: https://github.com/PyCQA/autoflake
+  rev: v2.3.1
   hooks:
     - id: autoflake
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']


### PR DESCRIPTION
The mirrors-autoflake pre-commit was giving the following error:
```
Traceback (most recent call last):
  File "/Users/stefmd/.cache/pre-commit/repou4rvvmfx/py_env-python3.12/bin/autoflake", line 5, in <module>
    from autoflake import main
  File "/Users/stefmd/.cache/pre-commit/repou4rvvmfx/py_env-python3.12/lib/python3.12/site-packages/autoflake.py", line 32, in <module>
    import distutils.sysconfig
ModuleNotFoundError: No module named 'distutils'
```
due to the fact that the [`mirrors-autoflake`](https://github.com/humitos/mirrors-autoflake?tab=readme-ov-file) repository that our ["autoflake" pre-commit hook](https://github.com/anmut-consulting/pipenv-cookiecutter/blob/67fb4c917f607424c2307f77dd1a57b8f4d4538c/%7B%7Bcookiecutter.repo_name%7D%7D/.pre-commit-config.yaml#L24) uses has been deprecated since the official [`autoflake`](https://github.com/PyCQA/autoflake/tree/v2.3.1) released functionality that supports its use with pre-commit, and therefore was stopped from being maintained more than 2 years ago.

In that time, python has deprecated its `distutils` module from version 3.10 onwards (can read up on that [here](https://stackoverflow.com/questions/77233855/why-did-i-get-an-error-modulenotfounderror-no-module-named-distutils)), which `mirrors-autoflake` still relies on, meaning it will always give the same error within our pre-commit setup (that seems to be using 3.12 as default as can be seen from the python ref in the error traceback).

To solve this, I have opted to point our "autoflake" pre-commit hook in the direction of the latest version of the official `autoflake` repo which doesn't have this dependency. Rather than override pre-commit's [default_language_version](https://pre-commit.com/#top_level-default_language_version) to 3.8 (or any version < 3.10).